### PR TITLE
Fix tap handling on iPad and disable zoom

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,12 +71,25 @@ function buildPeriodic(){
       }
       div.innerHTML = `<div class="num">${e.atomicNumber}</div><div class="sym">${e.symbol}</div>`;
       div.addEventListener("click", () => addAtom(e.symbol, 1));
+
       let pressTimer=null;
-      div.addEventListener("touchstart", (ev)=>{ ev.preventDefault(); pressTimer=setTimeout(()=> showFact(e), 600); }, {passive:false});
-      const cancel=(ev)=>{ if(ev) ev.preventDefault(); if(pressTimer){ clearTimeout(pressTimer); pressTimer=null; } };
-      div.addEventListener("touchend", cancel, {passive:false});
-      div.addEventListener("touchmove", cancel, {passive:false});
-      div.addEventListener("touchcancel", cancel, {passive:false});
+      let longPress=false;
+      // handle long-press facts while still allowing simple taps on touch devices
+      div.addEventListener("touchstart", ()=>{
+        longPress=false;
+        pressTimer=setTimeout(()=>{ longPress=true; showFact(e); }, 600);
+      }, {passive:true});
+      const cancel=()=>{ if(pressTimer){ clearTimeout(pressTimer); pressTimer=null; } };
+      div.addEventListener("touchmove", cancel, {passive:true});
+      div.addEventListener("touchcancel", cancel, {passive:true});
+      div.addEventListener("touchend", (ev)=>{
+        if(pressTimer){
+          clearTimeout(pressTimer);
+          pressTimer=null;
+          if(!longPress) addAtom(e.symbol,1);
+        }
+        ev.preventDefault();
+      }, {passive:false});
       div.addEventListener("contextmenu", (ev)=>{ev.preventDefault(); showFact(e);});
       grid.appendChild(div);
     }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, maximum-scale=1" />
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <link rel="manifest" href="manifest.webmanifest">


### PR DESCRIPTION
## Summary
- allow touch taps to add atoms while preserving long-press facts
- disable zoom gestures on mobile by setting viewport constraints

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c692e9dc832e85ba893069319c56